### PR TITLE
Update DMXOutputUsingUSART.ino

### DIFF
--- a/examples/DMXOutputUsingUSART/DMXOutputUsingUSART.ino
+++ b/examples/DMXOutputUsingUSART/DMXOutputUsingUSART.ino
@@ -216,6 +216,7 @@ void setup() {
 *************************************************************************/
 
 void loop() {
+	Ethernet.maintain();
 	uint8_t result = interface->readDMXPacket(&eUDP);
 
   if ( result == RESULT_DMX_RECEIVED ) {


### PR DESCRIPTION
add "Ethernet.maintain()" to loop. 
This should enable obtaining an ip-adress via dhcp if inital try fails.
A quick basic test resulted in a success